### PR TITLE
Support multiple databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ class CreateActsAsDagTables < ActiveRecord::Migration
 end
 ```
 
+If you have a multi-database setup, make sure to create the tables in the same database where your DAG ActiveRecord models are located.
+
 ### Usage
 
 ```ruby

--- a/lib/acts_as_dag/acts_as_dag.rb
+++ b/lib/acts_as_dag/acts_as_dag.rb
@@ -15,23 +15,37 @@ module ActsAsDAG
 
       # Create Link and Descendant Classes
       class_eval <<-RUBY
-        class ::#{options[:link_class]} < ActsAsDAG::AbstractLink
-          self.table_name = '#{options[:link_table]}'
-          belongs_to :parent, :class_name => '#{self.name}', :foreign_key => :parent_id, :inverse_of => :child_links, :optional => true
-          belongs_to :child, :class_name => '#{self.name}', :foreign_key => :child_id, :inverse_of => :parent_links, :optional => true
+        parent_class = ancestors.detect {it.respond_to?(:abstract_class) && it.abstract_class } || ActiveRecord::Base
 
-          after_save Proc.new {|link| HelperMethods.update_transitive_closure_for_new_link(link) }
-          after_destroy Proc.new {|link| HelperMethods.update_transitive_closure_for_destroyed_link(link) }
+        unless Object.const_defined?(options[:link_class])
+          class ::#{options[:link_class]} < parent_class
+            self.table_name = '#{options[:link_table]}'
+            belongs_to :parent, :class_name => '#{self.name}', :foreign_key => :parent_id, :inverse_of => :child_links, :optional => true
+            belongs_to :child, :class_name => '#{self.name}', :foreign_key => :child_id, :inverse_of => :parent_links, :optional => true
 
-          def node_class; #{self.name} end
+            after_save Proc.new {|link| HelperMethods.update_transitive_closure_for_new_link(link) }
+            after_destroy Proc.new {|link| HelperMethods.update_transitive_closure_for_destroyed_link(link) }
+
+            validate :not_self_referential
+
+            def not_self_referential
+              errors.add(:base, "Self referential links #{self.class} cannot be created.") if parent_id && parent_id == child_id
+            end
+
+            def node_class; #{self.name} end
+          end
         end
 
-        class ::#{options[:descendant_class]} < ActsAsDAG::AbstractDescendant
-          self.table_name = '#{options[:descendant_table]}'
-          belongs_to :ancestor, :class_name => '#{self.name}', :foreign_key => :ancestor_id, :optional => true
-          belongs_to :descendant, :class_name => '#{self.name}', :foreign_key => :descendant_id, :optional => true
+        unless Object.const_defined?(options[:descendant_class])
+          class ::#{options[:descendant_class]} < parent_class
+            self.table_name = '#{options[:descendant_table]}'
+            belongs_to :ancestor, :class_name => '#{self.name}', :foreign_key => :ancestor_id, :optional => true
+            belongs_to :descendant, :class_name => '#{self.name}', :foreign_key => :descendant_id, :optional => true
 
-          def node_class; #{self.name} end
+            validates_presence_of :ancestor_id, :descendant_id
+
+            def node_class; #{self.name} end
+          end
         end
 
         def self.link_class
@@ -401,22 +415,5 @@ module ActsAsDAG
         rebuild_subtree_links(child, path.dup)
       end
     end
-  end
-
-  # CLASSES (for providing hooks)
-  class AbstractLink < ActiveRecord::Base
-    self.abstract_class = true
-
-    validate :not_self_referential
-
-    def not_self_referential
-      errors.add(:base, "Self referential links #{self.class} cannot be created.") if parent_id && parent_id == child_id
-    end
-  end
-
-  class AbstractDescendant < ActiveRecord::Base
-    self.abstract_class = true
-
-    validates_presence_of :ancestor_id, :descendant_id
   end
 end

--- a/spec/acts_as_dag_spec.rb
+++ b/spec/acts_as_dag_spec.rb
@@ -1027,4 +1027,12 @@ describe 'acts_as_dag' do
       expect(record.subtree_links.first.category_type).to eq(klass.name)
     end
   end
+
+  if ActiveRecord::VERSION::MAJOR >= 6
+    describe "models connected to non-primary DBs" do
+      let(:klass) { AnotherDBModel }
+
+      it_should_behave_like "DAG Model"
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,35 @@ require 'acts_as_dag'
 
 puts ActiveRecord.version
 
+ENV['RAILS_ENV'] ||= 'test'
+
 ActiveRecord::Base.logger = Logger.new(STDOUT)
 ActiveRecord::Base.logger.level = Logger::WARN
-ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
+
+# ActiveRecord 6.0 and above supports multiple database connections
+if ActiveRecord::VERSION::MAJOR >= 6
+  ActiveRecord::Base.configurations = {
+    "test" => {
+      "primary" => {
+        "adapter" => "sqlite3",
+        "database" => "file:primary?mode=memory"
+      },
+      "other_database" => {
+        "adapter" => "sqlite3",
+        "database" => "file:other_db_memory?mode=memory"
+      }
+    }
+  }
+else
+  ActiveRecord::Base.configurations = {
+    "test" => {
+      "adapter" => "sqlite3",
+      "database" => "file:primary?mode=memory"
+    }
+  }
+end
+
+ActiveRecord::Base.establish_connection
 
 ActiveRecord::Schema.define(:version => 0) do
 
@@ -57,4 +83,38 @@ end
 
 class UnifiedLinkModel < ActiveRecord::Base
   acts_as_dag
+end
+
+if ActiveRecord::VERSION::MAJOR >= 6
+  class AnotherDBAbstractClass < ActiveRecord::Base
+    self.abstract_class = true
+
+    connects_to database: { writing: :other_database }
+  end
+
+  schema_class = ActiveRecord::Schema[ActiveRecord::Migration.current_version]
+  schema = schema_class.new
+  schema.instance_variable_set(:@connection, AnotherDBAbstractClass.connection)
+  schema.define(version: 0) do
+    create_table :another_db_models, force: true do |t|
+      t.string :name
+    end
+
+    create_table :acts_as_dag_links, :force => true do |t|
+      t.integer :parent_id
+      t.integer :child_id
+      t.string :category_type
+    end
+
+    create_table :acts_as_dag_descendants, :force => true do |t|
+      t.integer :ancestor_id
+      t.integer :descendant_id
+      t.integer :distance
+      t.string :category_type
+    end
+  end
+
+  class AnotherDBModel < AnotherDBAbstractClass
+    acts_as_dag
+  end
 end


### PR DESCRIPTION
Rails [natively supports multi-database setups](https://guides.rubyonrails.org/active_record_multiple_databases.html) starting with [version 6.0](https://guides.rubyonrails.org/v6.0/active_record_multiple_databases.html).

```ruby
class AnimalsModel < ApplicationRecord
  self.abstract_class = true

  connects_to database: { writing: :primary, reading: :primary_replica }
end
```

This PR updates `acts_as_dag` to select the correct database when defining link and descendant models by inheriting from the nearest abstract class. This change allows it to support multi-database setups.